### PR TITLE
Add support for Voice Settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ run
 .DS_Store
 Thumbs.db
 transformed/*
+
+# secrets
+/src/example/kotlin/dev/cbyrne/example/Secrets.kt

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,8 @@ dependencies {
     exampleImplementation(sourceSets.main.get().output)
 
     //For example
-    implementation("com.squareup.okhttp3:okhttp:4.9.3")
+    implementation("io.ktor:ktor-client-core:2.0.1")
+    implementation("io.ktor:ktor-client-cio:2.0.1")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.3.2")
 
     // Log4J is only used in the example project as a backend for SLF4j

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,10 @@ dependencies {
 
     exampleImplementation(sourceSets.main.get().output)
 
+    //For example
+    implementation("com.squareup.okhttp3:okhttp:4.9.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.3.2")
+
     // Log4J is only used in the example project as a backend for SLF4j
     exampleImplementation(libs.log4j.core)
     exampleImplementation(libs.log4j.api)

--- a/src/example/kotlin/dev/cbyrne/example/Main.kt
+++ b/src/example/kotlin/dev/cbyrne/example/Main.kt
@@ -5,6 +5,7 @@ import dev.cbyrne.kdiscordipc.core.event.DiscordEvent
 import dev.cbyrne.kdiscordipc.core.event.impl.*
 import dev.cbyrne.kdiscordipc.core.packet.outbound.impl.SetVoiceSettingsPacket
 import dev.cbyrne.kdiscordipc.core.util.Platform
+import dev.cbyrne.kdiscordipc.core.util.json
 import dev.cbyrne.kdiscordipc.core.util.platform
 import dev.cbyrne.kdiscordipc.data.activity.*
 import kotlinx.datetime.Clock
@@ -12,7 +13,6 @@ import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
 import okhttp3.*
 import okio.IOException
 import org.apache.logging.log4j.LogManager
@@ -63,7 +63,7 @@ suspend fun main() {
 
         var accessToken: String? = null
         if (authFile.exists()) {
-            val timelessResponse = Json.decodeFromString<TimelessOAuthResponse>(authFile.readText())
+            val timelessResponse = json.decodeFromString<TimelessOAuthResponse>(authFile.readText())
 
             if (timelessResponse.expiresOn < Clock.System.now()) {
                 val refreshBody =
@@ -79,7 +79,7 @@ suspend fun main() {
 
                 if (refreshResponse.body == null) throw Exception("error while getting access token")
 
-                val oauthResponse = Json.decodeFromString<OAuthResponse>(refreshResponse.body!!.string())
+                val oauthResponse = json.decodeFromString<OAuthResponse>(refreshResponse.body!!.string())
                 logger.info(oauthResponse)
 
                 accessToken = oauthResponse.accessToken
@@ -116,7 +116,7 @@ suspend fun main() {
 
             if (response.body == null) throw Exception("error while getting access token")
 
-            val oauthResponse = Json.decodeFromString<OAuthResponse>(response.body!!.string())
+            val oauthResponse = json.decodeFromString<OAuthResponse>(response.body!!.string())
             logger.info(oauthResponse)
 
             accessToken = oauthResponse.accessToken
@@ -193,7 +193,7 @@ fun saveOAuthResponse(response: OAuthResponse) {
     val dir = File("${System.getenv("APPDATA")}/KDiscordIPC")
     if (!dir.exists()) dir.mkdir()
     File("${System.getenv("APPDATA")}/KDiscordIPC/authentication.json").writeText(
-        Json.encodeToString(
+        json.encodeToString(
             TimelessOAuthResponse.serializer(), TimelessOAuthResponse(response)
         )
     )

--- a/src/example/kotlin/dev/cbyrne/example/Main.kt
+++ b/src/example/kotlin/dev/cbyrne/example/Main.kt
@@ -3,15 +3,28 @@ package dev.cbyrne.example
 import dev.cbyrne.kdiscordipc.KDiscordIPC
 import dev.cbyrne.kdiscordipc.core.event.DiscordEvent
 import dev.cbyrne.kdiscordipc.core.event.impl.*
+import dev.cbyrne.kdiscordipc.core.packet.outbound.impl.SetVoiceSettingsPacket
+import dev.cbyrne.kdiscordipc.core.util.Platform
+import dev.cbyrne.kdiscordipc.core.util.platform
 import dev.cbyrne.kdiscordipc.data.activity.*
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import okhttp3.*
+import okio.IOException
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import java.io.File
 import java.util.*
+import kotlin.time.Duration.Companion.seconds
 
 val logger: Logger = LogManager.getLogger("Example")
 
 suspend fun main() {
-    val ipc = KDiscordIPC("945428344806183003")
+    val ipc = KDiscordIPC(clientID)//"945428344806183003")
     logger.info("Starting example!")
 
     ipc.on<ReadyEvent> {
@@ -43,9 +56,84 @@ suspend fun main() {
         val relationships = ipc.relationshipManager.getRelationships()
         logger.info("Relationships: ${relationships.size}")
 
+        val dataFolder = File(if(platform == Platform.WINDOWS) "${System.getenv("APPDATA")}/KDiscordIPC" else "${System.getenv("HOME")}/.KDiscordIPC")
+        val authFile = File("${dataFolder.absolutePath}/authentication.json")
+
+        val okHttpClient = OkHttpClient()
+
+        var accessToken: String? = null
+        if (authFile.exists()) {
+            val timelessResponse = Json.decodeFromString<TimelessOAuthResponse>(authFile.readText())
+
+            if (timelessResponse.expiresOn < Clock.System.now()) {
+                val refreshBody =
+                    MultipartBody.Builder().setType(MultipartBody.FORM).addFormDataPart("client_id", clientID)
+                        .addFormDataPart("client_secret", clientSecret).addFormDataPart("grant_type", "refresh_token")
+                        .addFormDataPart("refresh_token", timelessResponse.refreshToken).build()
+
+                val refreshRequest = Request.Builder().header("Content-Type", "application/x-www-form-urlencoded")
+                    .url("https://discord.com/api/v8/oauth2/token").post(refreshBody).build()
+
+                val refreshResponse = okHttpClient.newCall(refreshRequest).execute()
+                if (!refreshResponse.isSuccessful) throw IOException("Unexpected code ${refreshResponse.code}")
+
+                if (refreshResponse.body == null) throw Exception("error while getting access token")
+
+                val oauthResponse = Json.decodeFromString<OAuthResponse>(refreshResponse.body!!.string())
+                logger.info(oauthResponse)
+
+                accessToken = oauthResponse.accessToken
+
+                saveOAuthResponse(oauthResponse)
+            } else {
+                accessToken = timelessResponse.accessToken
+            }
+        }
+
+        if (accessToken == null) {
+
+            val authorization =
+                ipc.applicationManager.authorize(arrayOf("rpc", "rpc.voice.read", "identify"), "971413122470531142")
+            logger.info("Authorization: $authorization")
+
+            val body = MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addFormDataPart("client_id", clientID)
+                .addFormDataPart("client_secret", clientSecret)
+                .addFormDataPart("grant_type", "authorization_code")
+                .addFormDataPart("code", authorization.code)
+                .addFormDataPart("redirect_uri", "http://127.0.0.1")
+                .build()
+
+            val request = Request.Builder()
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .url("https://discord.com/api/v8/oauth2/token")
+                .post(body)
+                .build()
+
+            val response = okHttpClient.newCall(request).execute()
+            if (!response.isSuccessful) throw IOException("Unexpected code $response")
+
+            if (response.body == null) throw Exception("error while getting access token")
+
+            val oauthResponse = Json.decodeFromString<OAuthResponse>(response.body!!.string())
+            logger.info(oauthResponse)
+
+            accessToken = oauthResponse.accessToken
+
+            saveOAuthResponse(oauthResponse)
+        }
+
         // Get an oauth token for the currently logged-in user
-        val oauthToken = ipc.applicationManager.getOAuthToken()
+        val oauthToken = ipc.applicationManager.getOAuthToken(accessToken)
         logger.info("Received oauth token from Discord! Expires on: ${oauthToken.expires}")
+
+        val voiceSettings = ipc.voiceSettingsManager.getVoiceSettings()
+        logger.info("Voice Settings: $voiceSettings")
+
+        ipc.voiceSettingsManager.setVoiceSettings(SetVoiceSettingsPacket.VoiceSettingArguments(mute = true))
+        ipc.voiceSettingsManager.subscribeToVoiceSettingsUpdate()
+
     }
 
     ipc.on<ErrorEvent> {
@@ -67,4 +155,42 @@ suspend fun main() {
     }
 
     ipc.connect()
+}
+
+@Suppress("unused")
+@Serializable
+data class OAuthResponse(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("token_type") val tokenType: String,
+    @SerialName("expires_in") val expiresIn: Int,
+    @SerialName("refresh_token") val refreshToken: String,
+    val scope: String
+)
+
+@Suppress("MemberVisibilityCanBePrivate", "unused")
+@Serializable
+class TimelessOAuthResponse(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("token_type") val tokenType: String,
+    @SerialName("expires_on") val expiresOn: Instant,
+    @SerialName("refresh_token") val refreshToken: String,
+    val scope: String
+) {
+    constructor(response: OAuthResponse) : this(
+        accessToken = response.accessToken,
+        tokenType = response.tokenType,
+        refreshToken = response.refreshToken,
+        scope = response.scope,
+        expiresOn = Clock.System.now() + response.expiresIn.seconds
+    )
+}
+
+fun saveOAuthResponse(response: OAuthResponse) {
+    val dir = File("${System.getenv("APPDATA")}/KDiscordIPC")
+    if (!dir.exists()) dir.mkdir()
+    File("${System.getenv("APPDATA")}/KDiscordIPC/authentication.json").writeText(
+        Json.encodeToString(
+            TimelessOAuthResponse.serializer(), TimelessOAuthResponse(response)
+        )
+    )
 }

--- a/src/example/kotlin/dev/cbyrne/example/Main.kt
+++ b/src/example/kotlin/dev/cbyrne/example/Main.kt
@@ -154,6 +154,10 @@ suspend fun main() {
         ipc.activityManager.acceptInvite(data)
     }
 
+    ipc.on<VoiceSettingsUpdateEvent> {
+        logger.info("Voice settings updated! User is now ${if (this.data.mute) "" else "not "} muted")
+    }
+
     ipc.connect()
 }
 

--- a/src/example/kotlin/dev/cbyrne/example/Main.kt
+++ b/src/example/kotlin/dev/cbyrne/example/Main.kt
@@ -93,7 +93,7 @@ suspend fun main() {
 
                     accessToken = oauthResponse.accessToken
 
-                    saveOAuthResponse(oauthResponse)
+                    saveOAuthResponse(oauthResponse, dataFolder, authFile)
                 } else {
                     accessToken = timelessResponse.accessToken
                 }
@@ -135,7 +135,7 @@ suspend fun main() {
 
             accessToken = oauthResponse.accessToken
 
-            saveOAuthResponse(oauthResponse)
+            saveOAuthResponse(oauthResponse, dataFolder, authFile)
         }
 
         // Authenticate with the client and get an oauth token for the currently logged-in user
@@ -204,10 +204,10 @@ class TimelessOAuthResponse(
     )
 }
 
-fun saveOAuthResponse(response: OAuthResponse) {
-    val dir = File("${System.getenv("APPDATA")}/KDiscordIPC")
-    if (!dir.exists()) dir.mkdir()
-    File("${System.getenv("APPDATA")}/KDiscordIPC/authentication.json").writeText(
+fun saveOAuthResponse(response: OAuthResponse, directory: File, file: File) {
+
+    if (!directory.exists()) directory.mkdir()
+    file.writeText(
         json.encodeToString(
             TimelessOAuthResponse.serializer(), TimelessOAuthResponse(response)
         )

--- a/src/example/kotlin/dev/cbyrne/example/Main.kt
+++ b/src/example/kotlin/dev/cbyrne/example/Main.kt
@@ -125,7 +125,7 @@ suspend fun main() {
         }
 
         // Get an oauth token for the currently logged-in user
-        val oauthToken = ipc.applicationManager.getOAuthToken(accessToken)
+        val oauthToken = ipc.applicationManager.authenticate(accessToken)
         logger.info("Received oauth token from Discord! Expires on: ${oauthToken.expires}")
 
         val voiceSettings = ipc.voiceSettingsManager.getVoiceSettings()

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/KDiscordIPC.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/KDiscordIPC.kt
@@ -14,10 +14,7 @@ import dev.cbyrne.kdiscordipc.core.packet.outbound.impl.HandshakePacket
 import dev.cbyrne.kdiscordipc.core.packet.outbound.impl.SubscribePacket
 import dev.cbyrne.kdiscordipc.core.packet.pipeline.MessageToByteEncoder
 import dev.cbyrne.kdiscordipc.core.socket.handler.SocketHandler
-import dev.cbyrne.kdiscordipc.manager.impl.ActivityManager
-import dev.cbyrne.kdiscordipc.manager.impl.ApplicationManager
-import dev.cbyrne.kdiscordipc.manager.impl.RelationshipManager
-import dev.cbyrne.kdiscordipc.manager.impl.UserManager
+import dev.cbyrne.kdiscordipc.manager.impl.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -39,6 +36,7 @@ class KDiscordIPC(private val clientID: String) {
     val applicationManager = ApplicationManager(this)
     val relationshipManager = RelationshipManager(this)
     val userManager = UserManager(this)
+    val voiceSettingsManager = VoiceSettingsManager(this)
 
     val scope = CoroutineScope(Job() + Dispatchers.IO)
 
@@ -58,6 +56,7 @@ class KDiscordIPC(private val clientID: String) {
         applicationManager.init()
         relationshipManager.init()
         userManager.init()
+        voiceSettingsManager.init()
 
         socketHandler.connect()
         writePacket(HandshakePacket(1, clientID))

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/KDiscordIPC.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/KDiscordIPC.kt
@@ -65,6 +65,7 @@ class KDiscordIPC(private val clientID: String) {
             when (it) {
                 is DispatchEventPacket.Ready -> _events.emit(ReadyEvent(it.data))
                 is DispatchEventPacket.UserUpdate -> _events.emit(CurrentUserUpdateEvent(it.data))
+                is DispatchEventPacket.VoiceSettingsUpdate -> _events.emit(VoiceSettingsUpdateEvent(it.data))
                 is DispatchEventPacket.ActivityJoin -> _events.emit(ActivityJoinEvent(it.data))
                 is DispatchEventPacket.ActivityInvite -> _events.emit(ActivityInviteEvent(it.data))
                 is ErrorPacket -> _events.emit(ErrorEvent(ErrorEventData(it.code, it.message)))

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/event/DiscordEvent.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/event/DiscordEvent.kt
@@ -18,5 +18,6 @@ enum class DiscordEvent(val eventName: String) {
     LobbyMessage("LOBBY_MESSAGE"),
     SpeakingStart("SPEAKING_START"),
     SpeakingStop("SPEAKING_STOP"),
-    RelationshipUpdate("RELATIONSHIP_UPDATE")
+    RelationshipUpdate("RELATIONSHIP_UPDATE"),
+    VoiceSettingsUpdate("VOICE_SETTINGS_UPDATE")
 }

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/event/impl/VoiceSettingsUpdateEvent.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/event/impl/VoiceSettingsUpdateEvent.kt
@@ -1,0 +1,6 @@
+package dev.cbyrne.kdiscordipc.core.event.impl
+
+import dev.cbyrne.kdiscordipc.core.event.Event
+import dev.cbyrne.kdiscordipc.data.voiceSettings.VoiceSettings
+
+data class VoiceSettingsUpdateEvent(val data: VoiceSettings): Event

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/inbound/impl/AuthorizePacket.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/inbound/impl/AuthorizePacket.kt
@@ -1,0 +1,16 @@
+package dev.cbyrne.kdiscordipc.core.packet.inbound.impl
+
+import dev.cbyrne.kdiscordipc.core.packet.inbound.CommandPacket
+import dev.cbyrne.kdiscordipc.core.packet.inbound.InboundPacket
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AuthorizePacket(
+    override val data: Data,
+    override val cmd: String = "AUTHORIZE",
+    override val opcode: Int = 0x01,
+    override val nonce: String = "0"
+): CommandPacket() {
+    @Serializable
+    data class Data(val code: String): InboundPacket.Data()
+}

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/inbound/impl/DispatchEventPacket.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/inbound/impl/DispatchEventPacket.kt
@@ -6,6 +6,7 @@ import dev.cbyrne.kdiscordipc.core.event.data.EventData
 import dev.cbyrne.kdiscordipc.core.event.data.ReadyEventData
 import dev.cbyrne.kdiscordipc.core.packet.inbound.CommandPacket
 import dev.cbyrne.kdiscordipc.data.user.User
+import dev.cbyrne.kdiscordipc.data.voiceSettings.VoiceSettings
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -24,6 +25,11 @@ abstract class DispatchEventPacket(
     @Serializable
     data class UserUpdate(
         override val data: User
+    ) : DispatchEventPacket()
+
+    @Serializable
+    data class VoiceSettingsUpdate(
+        override val data: VoiceSettings
     ) : DispatchEventPacket()
 
     @Serializable

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/inbound/impl/VoiceSettingsPacket.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/inbound/impl/VoiceSettingsPacket.kt
@@ -1,0 +1,21 @@
+package dev.cbyrne.kdiscordipc.core.packet.inbound.impl
+
+import dev.cbyrne.kdiscordipc.core.packet.inbound.CommandPacket
+import dev.cbyrne.kdiscordipc.data.voiceSettings.VoiceSettings
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetVoiceSettingsPacket(
+    override val data: VoiceSettings,
+    override val cmd: String = "GET_VOICE_SETTINGS",
+    override val opcode: Int = 0x01,
+    override val nonce: String = "0"
+) : CommandPacket()
+
+@Serializable
+data class SetVoiceSettingsPacket(
+    override val data: VoiceSettings,
+    override val cmd: String? = "SET_VOICE_SETTINGS",
+    override val opcode: Int = 0x01,
+    override val nonce: String? = "0"
+): CommandPacket()

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/outbound/impl/AuthenticatePacket.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/outbound/impl/AuthenticatePacket.kt
@@ -11,10 +11,10 @@ data class AuthenticatePacket(
     override val opcode: Int = 0x01,
     override var nonce: String = "0"
 ) : CommandPacket() {
-    constructor(token: String) : this(args = Arguments(token))
+    constructor(token: String?) : this(args = Arguments(token))
 
     @Serializable
     data class Arguments(
-        @SerialName("access_token") val token: String
+        @SerialName("access_token") val token: String?
     ) : OutboundPacket.Arguments()
 }

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/outbound/impl/AuthorizePacket.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/outbound/impl/AuthorizePacket.kt
@@ -5,16 +5,17 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class AuthenticatePacket(
+data class AuthorizePacket(
     override val args: Arguments,
-    override val cmd: String = "AUTHENTICATE",
+    override val cmd: String = "AUTHORIZE",
     override val opcode: Int = 0x01,
     override var nonce: String = "0"
-) : CommandPacket() {
-    constructor(token: String) : this(args = Arguments(token))
+): CommandPacket() {
+    constructor(scopes: Array<String>, clientID: String): this(args = Arguments(scopes, clientID))
 
     @Serializable
     data class Arguments(
-        @SerialName("access_token") val token: String
-    ) : OutboundPacket.Arguments()
+        val scopes: Array<String>,
+        @SerialName("client_id") val clientID: String
+    ): OutboundPacket.Arguments()
 }

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/outbound/impl/AuthorizePacket.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/outbound/impl/AuthorizePacket.kt
@@ -11,11 +11,13 @@ data class AuthorizePacket(
     override val opcode: Int = 0x01,
     override var nonce: String = "0"
 ): CommandPacket() {
-    constructor(scopes: Array<String>, clientID: String): this(args = Arguments(scopes, clientID))
+    constructor(scopes: Array<String>?, clientID: String?, rpcToken: String?, username: String?): this(args = Arguments(scopes, clientID, rpcToken, username))
 
     @Serializable
     data class Arguments(
-        val scopes: Array<String>,
-        @SerialName("client_id") val clientID: String
+        val scopes: Array<String>?,
+        @SerialName("client_id") val clientID: String?,
+        @SerialName("rpc_token") val rpcToken: String?,
+        val username: String?
     ): OutboundPacket.Arguments()
 }

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/outbound/impl/VoiceSettingsPacket.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/outbound/impl/VoiceSettingsPacket.kt
@@ -21,7 +21,6 @@ data class SetVoiceSettingsPacket(
     override val args: VoiceSettingArguments,
     override var nonce: String = "0"
 ): OutboundPacket(){
-
     @Serializable
     data class VoiceSettingArguments(
         override val input: InputOutput? = null,

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/outbound/impl/VoiceSettingsPacket.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/outbound/impl/VoiceSettingsPacket.kt
@@ -1,0 +1,39 @@
+package dev.cbyrne.kdiscordipc.core.packet.outbound.impl
+
+import dev.cbyrne.kdiscordipc.core.packet.outbound.OutboundPacket
+import dev.cbyrne.kdiscordipc.data.voiceSettings.InputOutput
+import dev.cbyrne.kdiscordipc.data.voiceSettings.Mode
+import dev.cbyrne.kdiscordipc.data.voiceSettings.VoiceSettingsInterface
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetVoiceSettingsPacket(
+    override val opcode: Int = 0x01,
+    override val cmd: String = "GET_VOICE_SETTINGS",
+    override val args: Arguments? = null,
+    override var nonce: String = "0"
+): OutboundPacket(){
+}
+
+@Serializable
+data class SetVoiceSettingsPacket(
+    override val opcode: Int = 0x01,
+    override val cmd: String = "SET_VOICE_SETTINGS",
+    override val args: VoiceSettingArguments,
+    override var nonce: String = "0"
+): OutboundPacket(){
+
+    @Serializable
+    data class VoiceSettingArguments(
+        override val input: InputOutput? = null,
+        override val output: InputOutput? = null,
+        override val mode: Mode? = null,
+        override val automaticGainControl: Boolean? = null,
+        override val echoCancellation: Boolean? = null,
+        override val noiseSuppression: Boolean? = null,
+        override val qos: Boolean? = null,
+        override val silenceWarnings: Boolean? = null,
+        override val mute: Boolean? = null,
+        override val deaf: Boolean? = null
+    ): Arguments(), VoiceSettingsInterface
+}

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/outbound/impl/VoiceSettingsPacket.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/outbound/impl/VoiceSettingsPacket.kt
@@ -12,8 +12,7 @@ data class GetVoiceSettingsPacket(
     override val cmd: String = "GET_VOICE_SETTINGS",
     override val args: Arguments? = null,
     override var nonce: String = "0"
-): OutboundPacket(){
-}
+): OutboundPacket()
 
 @Serializable
 data class SetVoiceSettingsPacket(

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/serialization/InboundPacketSerializer.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/serialization/InboundPacketSerializer.kt
@@ -11,12 +11,16 @@ object InboundPacketSerializer : JsonContentPolymorphicSerializer<InboundPacket>
             "DISPATCH" -> when (val event = element.contentOrNull("evt")) {
                 "READY" -> DispatchEventPacket.Ready.serializer()
                 "CURRENT_USER_UPDATE" -> DispatchEventPacket.UserUpdate.serializer()
+                "VOICE_SETTINGS_UPDATE" -> DispatchEventPacket.VoiceSettingsUpdate.serializer()
                 "ACTIVITY_JOIN" -> DispatchEventPacket.ActivityJoin.serializer()
                 "ACTIVITY_INVITE" -> DispatchEventPacket.ActivityInvite.serializer()
                 else -> error("Unknown DISPATCH event: $event")
             }
             "SET_ACTIVITY" -> SetActivityPacket.serializer()
             "AUTHENTICATE" -> AuthenticatePacket.serializer()
+            "AUTHORIZE" -> AuthorizePacket.serializer()
+            "GET_VOICE_SETTINGS" -> GetVoiceSettingsPacket.serializer()
+            "SET_VOICE_SETTINGS" -> SetVoiceSettingsPacket.serializer()
             "GET_USER" -> GetUserPacket.serializer()
             "GET_RELATIONSHIPS" -> GetRelationshipsPacket.serializer()
             "SUBSCRIBE" -> SubscribePacket.serializer()

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/util/temporaryDirectory.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/util/temporaryDirectory.kt
@@ -1,4 +1,4 @@
 package dev.cbyrne.kdiscordipc.core.util
 
 val temporaryDirectory =
-    System.getenv("XDG_RUNTIME_DIR") ?: System.getenv("TMPDIR") ?: System.getenv("TMP") ?: System.getenv("TMPDIR")
+    System.getenv("XDG_RUNTIME_DIR") ?: System.getenv("TMPDIR") ?: System.getenv("TMP")

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/data/voiceSettings/VoiceSettings.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/data/voiceSettings/VoiceSettings.kt
@@ -47,14 +47,12 @@ data class InputOutput(
     @SerialName("device_id") val deviceId: String? = null,
     val volume: Float? = null
 ){
-
     @Serializable
     data class Device(
         val id: String,
         val name: String
     )
 }
-
 @Serializable
 data class Mode(
     val type: String,
@@ -63,7 +61,6 @@ data class Mode(
     val shortcut: Array<ShortCutKeyCombo>,
     val delay: Float
 ) {
-
     @Serializable
     data class ShortCutKeyCombo(
         val type: Int,

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/data/voiceSettings/VoiceSettings.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/data/voiceSettings/VoiceSettings.kt
@@ -29,16 +29,16 @@ interface VoiceSettingsInterface {
 
 @Serializable
 data class VoiceSettings(
-    override val input: InputOutput? = null,
-    override val output: InputOutput? = null,
-    override val mode: Mode? = null,
-    override val automaticGainControl: Boolean? = null,
-    override val echoCancellation: Boolean? = null,
-    override val noiseSuppression: Boolean? = null,
-    override val qos: Boolean? = null,
-    override val silenceWarnings: Boolean? = null,
-    override val mute: Boolean? = null,
-    override val deaf: Boolean? = null
+    override val input: InputOutput,
+    override val output: InputOutput,
+    override val mode: Mode,
+    @SerialName("automatic_gain_control") override val automaticGainControl: Boolean,
+    @SerialName("echo_cancellation") override val echoCancellation: Boolean,
+    @SerialName("noise_suppression") override val noiseSuppression: Boolean,
+    override val qos: Boolean,
+    @SerialName("silence_warning") override val silenceWarnings: Boolean,
+    override val mute: Boolean,
+    override val deaf: Boolean
 ): EventData(), VoiceSettingsInterface
 
 @Serializable

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/data/voiceSettings/VoiceSettings.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/data/voiceSettings/VoiceSettings.kt
@@ -1,0 +1,74 @@
+package dev.cbyrne.kdiscordipc.data.voiceSettings
+
+import dev.cbyrne.kdiscordipc.core.event.data.EventData
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+interface VoiceSettingsInterface {
+    val input: InputOutput?
+    val output: InputOutput?
+    val mode: Mode?
+
+    @SerialName("automatic_gain_control")
+    val automaticGainControl: Boolean?
+
+    @SerialName("echo_cancellation")
+    val echoCancellation: Boolean?
+
+    @SerialName("noise_suppression")
+    val noiseSuppression: Boolean?
+
+    val qos: Boolean?
+
+    @SerialName("silence_warning")
+    val silenceWarnings: Boolean?
+
+    val mute: Boolean?
+    val deaf: Boolean?
+}
+
+@Serializable
+data class VoiceSettings(
+    override val input: InputOutput? = null,
+    override val output: InputOutput? = null,
+    override val mode: Mode? = null,
+    override val automaticGainControl: Boolean? = null,
+    override val echoCancellation: Boolean? = null,
+    override val noiseSuppression: Boolean? = null,
+    override val qos: Boolean? = null,
+    override val silenceWarnings: Boolean? = null,
+    override val mute: Boolean? = null,
+    override val deaf: Boolean? = null
+): EventData(), VoiceSettingsInterface
+
+@Serializable
+data class InputOutput(
+    @SerialName("available_devices") val availableDevices: Array<Device>? = null,
+    @SerialName("device_id") val deviceId: String? = null,
+    val volume: Float? = null
+){
+
+    @Serializable
+    data class Device(
+        val id: String,
+        val name: String
+    )
+}
+
+@Serializable
+data class Mode(
+    val type: String,
+    @SerialName("auto_threshold") val autoThreshold: Boolean,
+    val threshold: Float,
+    val shortcut: Array<ShortCutKeyCombo>,
+    val delay: Float
+) {
+
+    @Serializable
+    data class ShortCutKeyCombo(
+        val type: Int,
+        val code: Int,
+        val name: String
+    )
+}
+

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/manager/impl/ApplicationManager.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/manager/impl/ApplicationManager.kt
@@ -20,7 +20,7 @@ class ApplicationManager(override val ipc: KDiscordIPC) : Manager() {
      *
      * These bearer tokens are active for seven days, after which they will expire.
      */
-    suspend fun getOAuthToken(token: String? = null): InboundAuthenticatePacket.Data {
+    suspend fun authenticate(token: String? = null): InboundAuthenticatePacket.Data {
         val response: InboundAuthenticatePacket = ipc.sendPacket(AuthenticatePacket(token))
         return response.data
     }

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/manager/impl/ApplicationManager.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/manager/impl/ApplicationManager.kt
@@ -20,13 +20,13 @@ class ApplicationManager(override val ipc: KDiscordIPC) : Manager() {
      *
      * These bearer tokens are active for seven days, after which they will expire.
      */
-    suspend fun getOAuthToken(token: String): InboundAuthenticatePacket.Data {
+    suspend fun getOAuthToken(token: String? = null): InboundAuthenticatePacket.Data {
         val response: InboundAuthenticatePacket = ipc.sendPacket(AuthenticatePacket(token))
         return response.data
     }
 
-    suspend fun authorize(scopes: Array<String>, clientId: String): InboundAuthorizePacket.Data {
-        val response: InboundAuthorizePacket = ipc.sendPacket(AuthorizePacket(scopes, clientId))
+    suspend fun authorize(scopes: Array<String>? = null, clientId: String? = null, rpcToken: String? = null, username: String? = null): InboundAuthorizePacket.Data {
+        val response: InboundAuthorizePacket = ipc.sendPacket(AuthorizePacket(scopes, clientId, rpcToken, username))
         return response.data
     }
 }

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/manager/impl/ApplicationManager.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/manager/impl/ApplicationManager.kt
@@ -2,8 +2,10 @@ package dev.cbyrne.kdiscordipc.manager.impl
 
 import dev.cbyrne.kdiscordipc.KDiscordIPC
 import dev.cbyrne.kdiscordipc.core.packet.outbound.impl.AuthenticatePacket
+import dev.cbyrne.kdiscordipc.core.packet.outbound.impl.AuthorizePacket
 import dev.cbyrne.kdiscordipc.manager.Manager
 import dev.cbyrne.kdiscordipc.core.packet.inbound.impl.AuthenticatePacket as InboundAuthenticatePacket
+import dev.cbyrne.kdiscordipc.core.packet.inbound.impl.AuthorizePacket as InboundAuthorizePacket
 
 /**
  * This manager gives you access  to a bearer token for the currently connected Discord user, which you can then use against the Discord REST API.
@@ -18,8 +20,13 @@ class ApplicationManager(override val ipc: KDiscordIPC) : Manager() {
      *
      * These bearer tokens are active for seven days, after which they will expire.
      */
-    suspend fun getOAuthToken(): InboundAuthenticatePacket.Data {
-        val response: InboundAuthenticatePacket = ipc.sendPacket(AuthenticatePacket())
+    suspend fun getOAuthToken(token: String): InboundAuthenticatePacket.Data {
+        val response: InboundAuthenticatePacket = ipc.sendPacket(AuthenticatePacket(token))
+        return response.data
+    }
+
+    suspend fun authorize(scopes: Array<String>, clientId: String): InboundAuthorizePacket.Data {
+        val response: InboundAuthorizePacket = ipc.sendPacket(AuthorizePacket(scopes, clientId))
         return response.data
     }
 }

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/manager/impl/VoiceSettingsManager.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/manager/impl/VoiceSettingsManager.kt
@@ -17,7 +17,6 @@ class VoiceSettingsManager(override val ipc: KDiscordIPC) : Manager() {
     override suspend fun init() {
         ipc.on<VoiceSettingsUpdateEvent> {
             currentVoiceSettings = this.data
-            println(currentVoiceSettings!!.mute)
         }
     }
 

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/manager/impl/VoiceSettingsManager.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/manager/impl/VoiceSettingsManager.kt
@@ -1,0 +1,34 @@
+package dev.cbyrne.kdiscordipc.manager.impl
+
+import dev.cbyrne.kdiscordipc.KDiscordIPC
+import dev.cbyrne.kdiscordipc.core.event.DiscordEvent
+import dev.cbyrne.kdiscordipc.core.event.impl.VoiceSettingsUpdateEvent
+import dev.cbyrne.kdiscordipc.core.packet.outbound.impl.GetVoiceSettingsPacket
+import dev.cbyrne.kdiscordipc.core.packet.outbound.impl.SetVoiceSettingsPacket
+import dev.cbyrne.kdiscordipc.data.voiceSettings.VoiceSettings
+import dev.cbyrne.kdiscordipc.manager.Manager
+import dev.cbyrne.kdiscordipc.core.packet.inbound.impl.GetVoiceSettingsPacket as InboundGetVoiceSettingsPacket
+import dev.cbyrne.kdiscordipc.core.packet.inbound.impl.SetVoiceSettingsPacket as InboundSetVoiceSettingsPacket
+
+class VoiceSettingsManager(override val ipc: KDiscordIPC) : Manager() {
+    var currentVoiceSettings: VoiceSettings? = null
+        private set
+
+    override suspend fun init() {
+        ipc.on<VoiceSettingsUpdateEvent> {
+            currentVoiceSettings = this.data
+            println(currentVoiceSettings!!.mute)
+        }
+    }
+
+    suspend fun getVoiceSettings(): VoiceSettings {
+        val response: InboundGetVoiceSettingsPacket = ipc.sendPacket(GetVoiceSettingsPacket())
+        return response.data
+    }
+
+    suspend fun setVoiceSettings(settings: SetVoiceSettingsPacket.VoiceSettingArguments) {
+        ipc.sendPacket<InboundSetVoiceSettingsPacket>(SetVoiceSettingsPacket(args = settings))
+    }
+
+    suspend fun subscribeToVoiceSettingsUpdate() = ipc.subscribe(DiscordEvent.VoiceSettingsUpdate)
+}


### PR DESCRIPTION
This PR adds support for Voice Settings by 

- Implementing the `GET_VOICE_SETTINGS` and `SET_VOICE_SETTINGS` commands
- Implementing the `VOICE_SETTINGS_CHANGED` Event
- Implementing the authorization flow enabling different scopes by adding the `AUTHORIZE` command
- Renamed `getOAuthToken` to `authenticate` to represent the actual command name
- Changed example project to contain getting and setting voice settings
- Added a gitignored `secrets.kt` containing client id and secret