### PR TITLE
Allow CoroutineScope to be provided

### DIFF
--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/KDiscordIPC.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/KDiscordIPC.kt
@@ -42,13 +42,12 @@ import dev.cbyrne.kdiscordipc.core.packet.inbound.impl.SubscribePacket as Inboun
 
 class KDiscordIPC(
     private val clientID: String,
-    socketSupplier: () -> Socket = SocketProvider::systemDefault
+    socketSupplier: () -> Socket = SocketProvider::systemDefault,
+    scope: CoroutineScope = CoroutineScope(Job() + Dispatchers.IO)
 ) {
     companion object {
         internal val logger = LoggerFactory.getLogger("KDiscordIPC")
     }
-
-    val scope = CoroutineScope(Job() + Dispatchers.IO)
 
     private val socketHandler = SocketHandler(scope, socketSupplier)
 


### PR DESCRIPTION
I would love to provide different CoroutineScope with different Dispatcher.

This change allows developers to provide coroutineScope to be used by the library.