### PR TITLE
Version 0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KDiscordIPC
 
-``Current version: 0.2.1``
+``Current version: 0.2.2``
 
 A lightweight and easy to use Discord IPC wrapper for Kotlin
 
@@ -29,7 +29,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.caoimhebyrne:KDiscordIPC:0.2.1")
+    implementation("com.github.caoimhebyrne:KDiscordIPC:0.2.2")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "dev.cbyrne"
-version = "0.2.1"
+version = "0.2.2"
 
 repositories {
     mavenCentral()

--- a/src/example/kotlin/dev/cbyrne/example/Main.kt
+++ b/src/example/kotlin/dev/cbyrne/example/Main.kt
@@ -3,7 +3,7 @@ package dev.cbyrne.example
 import dev.cbyrne.kdiscordipc.KDiscordIPC
 import dev.cbyrne.kdiscordipc.core.event.DiscordEvent
 import dev.cbyrne.kdiscordipc.core.event.impl.*
-import dev.cbyrne.kdiscordipc.core.event.impl.internal.DisconnectedEvent
+import dev.cbyrne.kdiscordipc.core.event.impl.DisconnectedEvent
 import dev.cbyrne.kdiscordipc.data.activity.*
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/KDiscordIPC.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/KDiscordIPC.kt
@@ -11,7 +11,7 @@ import dev.cbyrne.kdiscordipc.core.event.impl.CurrentUserUpdateEvent
 import dev.cbyrne.kdiscordipc.core.event.impl.ErrorEvent
 import dev.cbyrne.kdiscordipc.core.event.impl.ReadyEvent
 import dev.cbyrne.kdiscordipc.core.event.impl.VoiceSettingsUpdateEvent
-import dev.cbyrne.kdiscordipc.core.event.impl.internal.DisconnectedEvent
+import dev.cbyrne.kdiscordipc.core.event.impl.DisconnectedEvent
 import dev.cbyrne.kdiscordipc.core.packet.inbound.InboundPacket
 import dev.cbyrne.kdiscordipc.core.packet.inbound.impl.DispatchEventPacket
 import dev.cbyrne.kdiscordipc.core.packet.inbound.impl.ErrorPacket

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/event/impl/DisconnectedEvent.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/event/impl/DisconnectedEvent.kt
@@ -1,0 +1,5 @@
+package dev.cbyrne.kdiscordipc.core.event.impl
+
+import dev.cbyrne.kdiscordipc.core.event.Event
+
+public class DisconnectedEvent : Event

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/event/impl/internal/DisconnectedEvent.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/event/impl/internal/DisconnectedEvent.kt
@@ -1,5 +1,0 @@
-package dev.cbyrne.kdiscordipc.core.event.impl.internal
-
-import dev.cbyrne.kdiscordipc.core.event.Event
-
-class DisconnectedEvent : Event

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/pipeline/ByteToMessageDecoder.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/pipeline/ByteToMessageDecoder.kt
@@ -12,6 +12,10 @@ object ByteToMessageDecoder {
     fun decode(packet: RawPacket): InboundPacket? {
         try {
             val data = packet.data.decodeToString()
+            if (data.isEmpty()) {
+                throw DecodeError.InvalidData
+            }
+
             KDiscordIPC.logger.debug("Decoding: $data")
 
             return json.decodeFromString<InboundPacket>(data)

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/pipeline/ByteToMessageDecoder.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/packet/pipeline/ByteToMessageDecoder.kt
@@ -7,6 +7,7 @@ import dev.cbyrne.kdiscordipc.core.socket.RawPacket
 import dev.cbyrne.kdiscordipc.core.util.json
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
+import java.lang.IllegalStateException
 
 object ByteToMessageDecoder {
     fun decode(packet: RawPacket): InboundPacket? {
@@ -22,6 +23,12 @@ object ByteToMessageDecoder {
         } catch (e: SerializationException) {
             // We didn't receive the full data, probably because the socket was closed.
             throw DecodeError.InvalidData
+        } catch (e: IllegalStateException) {
+            if (e.message?.lowercase()?.contains("unknown packet command") == true) {
+                return null
+            }
+
+            throw e
         } catch (e: Exception) {
             KDiscordIPC.logger.debug(
                 "Caught error when decoding packet (op: ${packet.opcode}, length: ${packet.length})",

--- a/src/main/kotlin/dev/cbyrne/kdiscordipc/core/socket/handler/SocketHandler.kt
+++ b/src/main/kotlin/dev/cbyrne/kdiscordipc/core/socket/handler/SocketHandler.kt
@@ -44,7 +44,8 @@ class SocketHandler(
                 ByteToMessageDecoder.decode(rawPacket)?.let { emit(it) }
             } catch (e: DecodeError) {
                 if (e is DecodeError.InvalidData) {
-                    throw ConnectionError.Disconnected
+                    KDiscordIPC.logger.error("Recieved invalid data, assuming that Discord has disconnected from the socket.")
+                    disconnect()
                 }
             } catch (e: IOException) {
                 if (!isDisconnectionException(e)) {


### PR DESCRIPTION
- Empty packet messages received from Discord no longer cause uncaught exceptions
- Exceptions will no longer been thrown when we are forcefully disconnected from the Discord socket
- Unknown packets will no longer throw an exception, they will just be ignored
- `DisconnectEvent` is now public and not internal